### PR TITLE
initial files for opening nfc settings

### DIFF
--- a/android/src/main/kotlin/de/florianweinaug/system_settings/SystemSettingsPlugin.kt
+++ b/android/src/main/kotlin/de/florianweinaug/system_settings/SystemSettingsPlugin.kt
@@ -29,6 +29,7 @@ public class SystemSettingsPlugin(private val registrar: Registrar): MethodCallH
       "location"            -> openSetting(Settings.ACTION_LOCATION_SOURCE_SETTINGS)
       "wifi"                -> openSetting(Settings.ACTION_WIFI_SETTINGS)
       "bluetooth"           -> openSetting(Settings.ACTION_BLUETOOTH_SETTINGS)
+      "nfc"                 -> openSetting(Settings.ACTION_NFC_SETTINGS)
       "security"            -> openSetting(Settings.ACTION_SECURITY_SETTINGS)
       "display"             -> openSetting(Settings.ACTION_DISPLAY_SETTINGS)
       "date"                -> openSetting(Settings.ACTION_DATE_SETTINGS)

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -40,6 +40,10 @@ class MyApp extends StatelessWidget {
                 onPressed: () => SystemSettings.bluetooth(),
               ),
               ElevatedButton(
+                child: Text('Nfc'),
+                onPressed: () => SystemSettings.nfc(),
+              ),
+              ElevatedButton(
                 child: Text('Security'),
                 onPressed: () => SystemSettings.security(),
               ),

--- a/lib/system_settings.dart
+++ b/lib/system_settings.dart
@@ -29,6 +29,10 @@ class SystemSettings {
     return await _channel.invokeMethod('bluetooth');
   }
 
+  static Future<void> nfc() async {
+    return await _channel.invokeMethod('nfc');
+  }
+
   static Future<void> security() async {
     return await _channel.invokeMethod('security');
   }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: system_settings
 description: Flutter plugin to open system and app settings on iOS and Android.
-version: 2.0.0
+version: 2.0.1
 homepage: https://github.com/fweinaug/system_settings
 repository: https://github.com/fweinaug/system_settings
 


### PR DESCRIPTION
didn't test this on IOS, tested on emulator without nfc, which causes the settings page of "connected devices" to appear.

works fine on samsung S9