### PR TITLE
Update SwiftSystemSettingsPlugin.swift

### DIFF
--- a/ios/Classes/SwiftSystemSettingsPlugin.swift
+++ b/ios/Classes/SwiftSystemSettingsPlugin.swift
@@ -9,16 +9,31 @@ public class SwiftSystemSettingsPlugin: NSObject, FlutterPlugin {
   }
 
   public func handle(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
-      openSettings()
+      openSettings(call.method)
   }
 
-  private func openSettings() {
-    if let url = URL(string: UIApplication.openSettingsURLString) {
-        if #available(iOS 10.0, *) {
-            UIApplication.shared.open(url, options: [:], completionHandler: nil)
-        } else {
-            UIApplication.shared.openURL(url)
+  private func openSettings(_ method: String) {
+    var url = URL(string: UIApplication.openSettingsURLString)
+
+    switch method {
+      case "app-notifications":
+        if #available(iOS 16, *) {
+          url = URL(string: UIApplication.openNotificationSettingsURLString)
         }
+        if #available(iOS 15.4, *) {
+          url = URL(string: UIApplicationOpenNotificationSettingsURLString)
+        }
+      default:
+        break
     }
+
+    if let url = url {
+      if #available(iOS 10.0, *) {
+          UIApplication.shared.open(url, options: [:], completionHandler: nil)
+      } else {
+          UIApplication.shared.openURL(url)
+      }
+    }
+    
   }
 }


### PR DESCRIPTION
Connected "app-notifications" to open notifications settings directly on iOS
Fixes #28 